### PR TITLE
Rename `private-key` to `credential` and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Basic usage for requests to the IdP looks like:
       :issuer           "http://sp.example.com/demo1/metadata.php"
       ;; state manager (discussed above) is optional, but if passed `request` will record the newly created request.
       :state-manager    state-manager
-      ;; :private-key is optional. If passed, sign the request with this key
-      :private-key      sp-private-key})
+      ;; :credential is optional. If passed, sign the request with this key and attach public key data, if present
+      :credential       sp-private-key})
     ;; create a Ring redirect response to the IDP URL; pass the request as base-64 encoded `SAMLRequest` query parameter
     (saml/idp-redirect-response "http://idp.example.com/SSOService.php"
                                 ;; This is RelayState. In the old version of the lib it was encrypted. In some cases,
@@ -54,6 +54,16 @@ Basic usage for requests to the IdP looks like:
                                 ;; automatic encryption support back is on the TODO list
                                 "http://sp.example.com/please/redirect/me/to/here"))
 ```
+
+The `:credential` can be used to sign the request to the IdP, and attach any public key information (if present). It will
+happily accept several formats, depending on the use-case:
+  - `private-key`: A PEM formatted string
+  - `[public-cert private-key]`: A tuple containing an X509 Certificate and a private key, both in PEM format
+  
+The `:credential` can also reference a keystore using a map with the following parameters:
+  - `{:filepath "/path/to/keystore"
+      :password "keystore-password"
+      :alias    "key-alias"}`
 
 ### Responses
 

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -60,7 +60,7 @@
                                 ;; If present, record the request
                                 state-manager
                                 ;; If present, we can sign the request
-                                private-key]
+                                credential]
                          :or   {request-id (str (java.util.UUID/randomUUID))}}]
   (assert acs-url)
   (assert idp-url)
@@ -84,7 +84,7 @@
     (when state-manager
       (state/record-request! state-manager (.getAttribute request "ID")))
     (cond-> request
-      private-key (crypto/sign private-key))))
+      credential (crypto/sign credential))))
 
 (defn uri-query-str
   ^String [clean-hash]

--- a/test/saml20_clj/crypto_test.clj
+++ b/test/saml20_clj/crypto_test.clj
@@ -15,7 +15,7 @@
                      :acs-url     "http://sp.example.com/demo1/index.php?acs"
                      :idp-url     "http://idp.example.com/SSOService.php"
                      :issuer      "http://sp.example.com/demo1/metadata.php"
-                     :private-key test/sp-private-key}))]
+                     :credential  test/sp-private-key}))]
       (is (= :valid
              (crypto/assert-signature-valid-when-present signed test/sp-cert)))
       (testing "Wrong certificate"

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -85,12 +85,12 @@
             "</samlp:AuthnRequest>"]
            (->> (t/with-clock (t/mock-clock (t/instant "2020-09-24T22:51:00.000Z"))
                   (request/request
-                   {:request-id  "ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
-                    :sp-name     "SP test"
-                    :acs-url     "http://sp.example.com/demo1/index.php?acs"
-                    :idp-url     "http://idp.example.com/SSOService.php"
-                    :issuer      "http://sp.example.com/demo1/metadata.php"
-                    :private-key test/sp-private-key}))
+                   {:request-id "ONELOGIN_809707f0030a5d00620c9d9df97f627afe9dcc24"
+                    :sp-name    "SP test"
+                    :acs-url    "http://sp.example.com/demo1/index.php?acs"
+                    :idp-url    "http://idp.example.com/SSOService.php"
+                    :issuer     "http://sp.example.com/demo1/metadata.php"
+                    :credential test/sp-private-key}))
                 coerce/->xml-string
                 str/split-lines
                 ;; for some reason it indents the XML differently on the REPL and in the tests


### PR DESCRIPTION
Because the credential can be used so flexibly, `private-key` is unclear