### PR TITLE
Add specs for metadata and request fns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,8 @@
    [potemkin "0.4.5"]
    [pretty "1.0.4"]
    [ring/ring-codec "1.1.2"]
-   [clojure.java-time "0.3.2"]]
+   [clojure.java-time "0.3.2"]
+   [org.clojure/spec.alpha "0.2.187"]]
 
   :profiles
   {:dev

--- a/project.clj
+++ b/project.clj
@@ -21,8 +21,10 @@
   [["opensaml" "https://build.shibboleth.net/nexus/content/repositories/releases/"]]
 
   :dependencies
-  [[org.clojure/tools.logging "1.1.0"]
+  [[org.clojure/spec.alpha "0.2.187"]
+   [org.clojure/tools.logging "1.1.0"]
    [com.onelogin/java-saml "2.5.0"]
+   [clojure.java-time "0.3.2"]
    [commons-io/commons-io "2.8.0"]
    [hiccup "1.0.5"]
    [org.opensaml/opensaml-core "3.4.5"]
@@ -32,9 +34,7 @@
    [org.opensaml/opensaml-xmlsec-impl "3.4.5"]
    [potemkin "0.4.5"]
    [pretty "1.0.4"]
-   [ring/ring-codec "1.1.2"]
-   [clojure.java-time "0.3.2"]
-   [org.clojure/spec.alpha "0.2.187"]]
+   [ring/ring-codec "1.1.2"]]
 
   :profiles
   {:dev

--- a/src/saml20_clj/sp/metadata.clj
+++ b/src/saml20_clj/sp/metadata.clj
@@ -1,31 +1,10 @@
 (ns saml20-clj.sp.metadata
-  (:require [clojure.spec.alpha :as s]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [saml20-clj
              [coerce :as coerce]
-             [encode-decode :as encode]
-             [specs :as specs]])
+             [encode-decode :as encode]])
   (:import javax.security.cert.X509Certificate))
 
-(defn url? [s]
-  (string? s))
-
-(s/def ::app-name string?)
-(s/def ::slo-url specs/url?)
-(s/def ::sp-cert (partial instance? X509Certificate))
-(s/def ::requests-signed boolean?)
-(s/def ::want-assertions-signed boolean?)
-
-(s/def ::metadata (s/keys :req-un [::specs/acs-url
-                                   ::app-name
-                                   ::sp-cert]
-                          :opt-un [::requests-signed
-                                   ::slo-url
-                                   ::want-assertions-signed]))
-
-(s/fdef metadata
-  :args (s/cat :args ::metadata)
-  :ret string?)
 (defn metadata [{:keys [app-name acs-url slo-url sp-cert
                         requests-signed
                         want-assertions-signed]

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -6,34 +6,14 @@
              [coerce :as coerce]
              [crypto :as crypto]
              [encode-decode :as encode-decode]
-             [specs :as specs]
              [state :as state]])
-  (:import org.opensaml.security.credential.Credential
-           org.w3c.dom.Element))
+  (:import org.w3c.dom.Element))
 
 (defn- format-instant
   "Converts a date-time to a SAML 2.0 time string."
   [instant]
   (t/format (t/format "YYYY-MM-dd'T'HH:mm:ss'Z'" (t/offset-date-time instant (t/zone-offset 0)))))
 
-(s/def ::request-id string?)
-(s/def ::sp-name string?)
-(s/def ::issuer specs/url?)
-(s/def ::state-manager (partial satisfies? state/StateManager))
-(s/def ::credential (partial instance? Credential))
-(s/def ::instant inst?)
-
-(s/def ::request (s/keys :req-un [::sp-name
-                                  ::specs/acs-url
-                                  ::specs/idp-url
-                                  ::issuer]
-                         :opt-un [::state-manager
-                                  ::credential
-                                  ::instant]))
-
-(s/fdef request
-  :args (s/cat :request ::request)
-  :ret (partial instance? Element))
 (defn request
   "Return XML elements that represent a SAML 2.0 auth request."
   ^Element [{:keys [ ;; e.g. something like a UUID
@@ -82,21 +62,6 @@
 (defn uri-query-str
   ^String [clean-hash]
   (codec/form-encode clean-hash))
-
-(s/def ::saml-request (partial satisfies? coerce/SerializeXMLString))
-(s/def ::relay-state string?)
-
-(s/def ::status int?)
-(s/def ::headers map?)
-(s/def ::body string?)
-
-(s/def ::ring-response (s/keys :req-un [::status ::headers ::body]))
-
-(s/fdef id-redirect-response
-  :args (s/cat :request ::saml-request
-               :idp-url ::specs/idp-url
-               :relay-state ::relay-state)
-  :ret ::ring-response)
 
 (defn idp-redirect-response
   "Return Ring response for HTTP 302 redirect."

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -6,32 +6,53 @@
              [coerce :as coerce]
              [crypto :as crypto]
              [encode-decode :as encode-decode]
-             [state :as state]]))
+             [specs :as specs]
+             [state :as state]])
+  (:import org.opensaml.security.credential.Credential
+           org.w3c.dom.Element))
 
 (defn- format-instant
   "Converts a date-time to a SAML 2.0 time string."
   [instant]
   (t/format (t/format "YYYY-MM-dd'T'HH:mm:ss'Z'" (t/offset-date-time instant (t/zone-offset 0)))))
 
+(s/def ::request-id string?)
+(s/def ::sp-name string?)
+(s/def ::issuer specs/url?)
+(s/def ::state-manager (partial satisfies? state/StateManager))
+(s/def ::credential (partial instance? Credential))
+(s/def ::instant inst?)
+
+(s/def ::request (s/keys :req-un [::sp-name
+                                  ::specs/acs-url
+                                  ::specs/idp-url
+                                  ::issuer]
+                         :opt-un [::state-manager
+                                  ::credential
+                                  ::instant]))
+
+(s/fdef request
+  :args (s/cat :request ::request)
+  :ret (partial instance? Element))
 (defn request
   "Return XML elements that represent a SAML 2.0 auth request."
-  ^org.w3c.dom.Element [{:keys [ ;; e.g. something like a UUID
-                                request-id
-                                ;; e.g. "Metabase"
-                                sp-name
-                                ;; e.g. ttp://sp.example.com/demo1/index.php?acs
-                                acs-url
-                                ;; e.g. http://sp.example.com/demo1/index.php?acs
-                                idp-url
-                                ;; e.g. http://idp.example.com/SSOService.php
-                                issuer
-                                ;; If present, record the request
-                                state-manager
-                                ;; If present, we can sign the request
-                                credential
-                                instant]
-                         :or   {request-id (str (java.util.UUID/randomUUID))
-                                instant (t/instant)}}]
+  ^Element [{:keys [ ;; e.g. something like a UUID
+                    request-id
+                    ;; e.g. "Metabase"
+                    sp-name
+                    ;; e.g. ttp://sp.example.com/demo1/index.php?acs
+                    acs-url
+                    ;; e.g. http://sp.example.com/demo1/index.php?acs
+                    idp-url
+                    ;; e.g. http://idp.example.com/SSOService.php
+                    issuer
+                    ;; If present, record the request
+                    state-manager
+                    ;; If present, we can sign the request
+                    credential
+                    instant]
+             :or   {request-id (str (java.util.UUID/randomUUID))
+                    instant (t/instant)}}]
   (assert acs-url)
   (assert idp-url)
   (assert sp-name)
@@ -61,6 +82,21 @@
 (defn uri-query-str
   ^String [clean-hash]
   (codec/form-encode clean-hash))
+
+(s/def ::saml-request (partial satisfies? coerce/SerializeXMLString))
+(s/def ::relay-state string?)
+
+(s/def ::status int?)
+(s/def ::headers map?)
+(s/def ::body string?)
+
+(s/def ::ring-response (s/keys :req-un [::status ::headers ::body]))
+
+(s/fdef id-redirect-response
+  :args (s/cat :request ::saml-request
+               :idp-url ::specs/idp-url
+               :relay-state ::relay-state)
+  :ret ::ring-response)
 
 (defn idp-redirect-response
   "Return Ring response for HTTP 302 redirect."

--- a/src/saml20_clj/specs.clj
+++ b/src/saml20_clj/specs.clj
@@ -1,0 +1,14 @@
+(ns saml20-clj.specs
+  (:require [clojure.spec.alpha :as s])
+  (:import java.net.URL))
+
+(defn url? [s]
+  (try
+    (URL. s)
+    true
+    (catch Exception _
+      false)))
+
+
+(s/def ::acs-url url?)
+(s/def ::idp-url url?)

--- a/src/saml20_clj/specs.clj
+++ b/src/saml20_clj/specs.clj
@@ -1,6 +1,15 @@
 (ns saml20-clj.specs
-  (:require [clojure.spec.alpha :as s])
-  (:import java.net.URL))
+  (:require [clojure.spec.alpha :as s]
+            [saml20-clj
+             [coerce :as coerce]
+             [state :as state]]
+            [saml20-clj.sp
+             [metadata :as metadata]
+             [request :as request]])
+  (:import java.net.URL
+           javax.security.cert.X509Certificate
+           org.opensaml.security.credential.Credential
+           org.w3c.dom.Element))
 
 (defn url? [s]
   (try
@@ -9,6 +18,57 @@
     (catch Exception _
       false)))
 
-
 (s/def ::acs-url url?)
 (s/def ::idp-url url?)
+(s/def ::issuer url?)
+(s/def ::slo-url url?)
+
+(s/def ::request-id string?)
+(s/def ::sp-name string?)
+(s/def ::app-name string?)
+
+(s/def ::state-manager (partial satisfies? state/StateManager))
+(s/def ::credential (partial instance? Credential))
+(s/def ::instant inst?)
+
+(s/def ::saml-request (partial satisfies? coerce/SerializeXMLString))
+(s/def ::relay-state string?)
+
+(s/def ::status int?)
+(s/def ::headers map?)
+(s/def ::body string?)
+
+(s/def ::sp-cert (partial instance? X509Certificate))
+(s/def ::requests-signed boolean?)
+(s/def ::want-assertions-signed boolean?)
+
+(s/def ::request (s/keys :req-un [::sp-name
+                                  ::acs-url
+                                  ::idp-url
+                                  ::issuer]
+                         :opt-un [::state-manager
+                                  ::credential
+                                  ::instant]))
+
+(s/def ::ring-response (s/keys :req-un [::status ::headers ::body]))
+
+(s/def ::metadata (s/keys :req-un [::acs-url
+                                   ::app-name
+                                   ::sp-cert]
+                          :opt-un [::requests-signed
+                                   ::slo-url
+                                   ::want-assertions-signed]))
+
+(s/fdef metadata/metadata
+  :args (s/cat :args ::metadata)
+  :ret string?)
+
+(s/fdef request/request
+  :args (s/cat :request ::request)
+  :ret (partial instance? Element))
+
+(s/fdef request/id-redirect-response
+  :args (s/cat :request ::saml-request
+               :idp-url ::idp-url
+               :relay-state ::relay-state)
+  :ret ::ring-response)


### PR DESCRIPTION
- introduce a new ns `specs` to hold common specs
- add fdefs to `metadata`, `request`, and `idp-redirect-response`