### PR TITLE
Add Support for Enforcing Encryption on Assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,14 @@ Basic usage for responses from the IdP looks like this (assuming a Ring `request
  ;; as implementations of saml20-clj.sp.response/validate-assertion.
  :assertion-validators
 
- ;; The default Assertion validators are:
+ ;; The available Assertion validators are:
  [;; If <Assertion> is signed, the signature matches the Assertion and the IdP certificate. If <Assertion> is not
   ;; signed, this validator does nothing.
   :signature
+ 
+  ;; If set, validation will ensure that all Assertions in the response are encrypted. If *any* unencrypted Assertions
+  ;; are present, verification will fail
+  :require-encryption
 
   ;; If :acs-url is non-nil, and <SubjectConfirmationData> is present, checks that <SubjectConfirmationData> has a
   ;; Recipient attribute matching this value.

--- a/src/saml20_clj/sp/response.clj
+++ b/src/saml20_clj/sp/response.clj
@@ -197,7 +197,7 @@
   Because we dispatch on the validator keywords, but only after decrypting the response,
   we use this to preserve the config setting without having to implement a dummy method"
   [options validator-type validator]
-  (if-let [config-setting (some #(= validator %) (get options validator-type))]
+  (if (some #(= validator %) (get options validator-type))
     (-> options
         (update-in [validator-type] (fn [e] (remove #(= % validator) e)))
         (assoc validator true))

--- a/src/saml20_clj/sp/response.clj
+++ b/src/saml20_clj/sp/response.clj
@@ -28,6 +28,14 @@
         (crypto/recursive-decrypt! sp-private-key element)
         (coerce/->Response element)))))
 
+(defn ensure-encrypted-assertions
+  ^Response [response]
+  (when-let [response (coerce/->Response response)]
+    (let [num-assertions           (count (.getAssertions response))
+          num-encrypted-assertions (count (.getEncryptedAssertions response))]
+      (when (> num-assertions num-encrypted-assertions)
+        (throw (ex-info "Unencrypted assertions present in response body" {}))))))
+
 (defn opensaml-assertions
   [response]
   (when-let [response (coerce/->Response response)]
@@ -184,6 +192,17 @@
                           :in-response-to
                           :address]})
 
+(defn- move-validator-config
+  "Raises one of the validation settings from a nested map up into the main config.
+  Because we dispatch on the validator keywords, but only after decrypting the response,
+  we use this to preserve the config setting without having to implement a dummy method"
+  [options validator-type validator]
+  (if-let [config-setting (some #(= validator %) (get options validator-type))]
+    (-> options
+        (update-in [validator-type] (fn [e] (remove #(= % validator) e)))
+        (assoc validator true))
+    options))
+
 (defn validate
   "Validate response. Returns decrypted response if valid."
   ([response idp-cert sp-private-key]
@@ -191,7 +210,10 @@
 
   ([response idp-cert sp-private-key options]
    (let [{:keys [response-validators assertion-validators], :as options} (-> (merge default-validation-options options)
-                                                                             (assoc :idp-cert (coerce/->Credential idp-cert)))]
+                                                                             (assoc :idp-cert (coerce/->Credential idp-cert))
+                                                                             (move-validator-config :assertion-validators :require-encryption))]
+     (when (:require-encryption options)
+       (ensure-encrypted-assertions response))
      (when-let [response (coerce/->Response response)]
        (let [decrypted-response (if sp-private-key
                                   (decrypt-response response sp-private-key)

--- a/test/saml20_clj/test.clj
+++ b/test/saml20_clj/test.clj
@@ -94,6 +94,9 @@
 (defn signed? [response-map]
   ((some-fn :message-signed? :assertion-signed?) response-map))
 
+(defn assertions-encrypted? [response-map]
+  ((some-fn :assertion-encrypted?) response-map))
+
 (defn valid-confirmation-data? [response-map]
   ((some-fn :valid-confirmation-data?) response-map))
 


### PR DESCRIPTION
Add a new flag to `:response-validators` and accompanying logic
to check the number of encrypted and unencrypted assertions found
on the response