### PR TITLE
Multiple of the same Attribute Nodes now retain all attribute values

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
  {"opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :deps
- {org.clojure/spec.alpha              {:mvn/version "0.3.218"}
+ {org.clojure/clojure                 {:mvn/version "1.11.1"}
+  org.clojure/spec.alpha              {:mvn/version "0.3.218"}
   org.clojure/tools.logging           {:mvn/version "1.2.4"}
   com.onelogin/java-saml              {:mvn/version "2.9.0"}
   clojure.java-time/clojure.java-time {:mvn/version "0.3.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,7 @@
  {"opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :deps
- {org.clojure/clojure                 {:mvn/version "1.11.1"}
-  org.clojure/spec.alpha              {:mvn/version "0.3.218"}
+ {org.clojure/spec.alpha              {:mvn/version "0.3.218"}
   org.clojure/tools.logging           {:mvn/version "1.2.4"}
   com.onelogin/java-saml              {:mvn/version "2.9.0"}
   clojure.java-time/clojure.java-time {:mvn/version "0.3.3"}

--- a/src/saml20_clj/sp/response.clj
+++ b/src/saml20_clj/sp/response.clj
@@ -358,11 +358,13 @@
           subject      (.getSubject assertion)
           subject-data (.getSubjectConfirmationData ^SubjectConfirmation (first (.getSubjectConfirmations subject)))
           name-id      (.getNameID subject)
-          attrs        (into {} (for [^AttributeStatement statement statements
-                                      ^Attribute attribute          (.getAttributes statement)]
-                                               [(saml2-attr->name (.getName attribute)) ; Or (.getFriendlyName a) ??
-                                                (map #(-> ^org.opensaml.core.xml.XMLObject % .getDOM .getTextContent)
-                                                     (.getAttributeValues attribute))]))
+          attrs        (as-> (for [^AttributeStatement statement statements
+                                   ^Attribute attribute          (.getAttributes statement)]
+                               [(saml2-attr->name (.getName attribute)) ; Or (.getFriendlyName a) ??
+                                (map #(-> ^org.opensaml.core.xml.XMLObject % .getDOM .getTextContent)
+                                     (.getAttributeValues attribute))]) <>
+                         (group-by first <>)
+                         (update-vals <> #(mapcat second %)))
           audiences    (for [^AudienceRestriction restriction (.. assertion getConditions getAudienceRestrictions)
                              ^Audience audience               (.getAudiences restriction)]
                                       (.getAudienceURI audience))]

--- a/src/saml20_clj/sp/response.clj
+++ b/src/saml20_clj/sp/response.clj
@@ -358,13 +358,12 @@
           subject      (.getSubject assertion)
           subject-data (.getSubjectConfirmationData ^SubjectConfirmation (first (.getSubjectConfirmations subject)))
           name-id      (.getNameID subject)
-          attrs        (as-> (for [^AttributeStatement statement statements
-                                   ^Attribute attribute          (.getAttributes statement)]
-                               [(saml2-attr->name (.getName attribute)) ; Or (.getFriendlyName a) ??
-                                (map #(-> ^org.opensaml.core.xml.XMLObject % .getDOM .getTextContent)
-                                     (.getAttributeValues attribute))]) <>
-                         (group-by first <>)
-                         (update-vals <> #(mapcat second %)))
+          attrs        (->> (for [^AttributeStatement statement statements
+                                  ^Attribute attribute          (.getAttributes statement)]
+                              {(saml2-attr->name (.getName attribute)) ; Or (.getFriendlyName a) ??
+                               (map #(-> ^org.opensaml.core.xml.XMLObject % .getDOM .getTextContent)
+                                    (.getAttributeValues attribute))})
+                            (apply (partial merge-with concat)))
           audiences    (for [^AudienceRestriction restriction (.. assertion getConditions getAudienceRestrictions)
                              ^Audience audience               (.getAudiences restriction)]
                                       (.getAudienceURI audience))]

--- a/test/saml20_clj/sp/response_test.clj
+++ b/test/saml20_clj/sp/response_test.clj
@@ -291,4 +291,14 @@
                              :address         "192.168.1.1",
                              :recipient       "http://sp.example.com/demo1/index.php?acs"}}
              (response/Assertion->map
-              (first (response/opensaml-assertions (coerce/->Response response)))))))))
+               (first (response/opensaml-assertions (coerce/->Response response))))))))
+  (testing "Attribute Nodes sharing a Name will collect all of their contained Attribute Value Nodes."
+    (let [response (test/response {})]
+      (is (= {"uid"                  '("test")
+              "mail"                 '("test@example.com")
+              ;; this key comes from an Attribute Node with two AttributeValue nodes inside
+              "eduPersonAffiliation" '("users" "examplerole1")
+              ;; this key is from two Attribute nodes with the same Name
+              "member_of"            '("test-group1" "test-group2" "test-group3")}
+             (:attrs (response/Assertion->map
+                       (first (response/opensaml-assertions (coerce/->Response response))))))))))

--- a/test/saml20_clj/test/response-unsigned.xml
+++ b/test/saml20_clj/test/response-unsigned.xml
@@ -33,6 +33,13 @@
         <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
         <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
       </saml:Attribute>
+      <saml:Attribute Name="member_of" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test-group1</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="member_of" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test-group2</saml:AttributeValue>
+        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test-group3</saml:AttributeValue>
+      </saml:Attribute>
     </saml:AttributeStatement>
   </saml:Assertion>
 </samlp:Response>


### PR DESCRIPTION
This is related to https://github.com/metabase/metabase/issues/20744

If an IdP sends a response containing some Attribute nodes as follows:
```
...
      <saml:Attribute Name="member_of" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test-group1</saml:AttributeValue>
      </saml:Attribute>
      <saml:Attribute Name="member_of" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
        <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test-group2</saml:AttributeValue>
      </saml:Attribute>
...
```
then previously the first value was discarded as only the last node/value is merged into the attributes map in `Assertion->map`.

Now, attribute nodes are grouped and their attribute value nodes are concatenated.