### PR TITLE
Bump OpenSAML from 3.4.6 to 4.2.0. Drop Java 8 support.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,16 +11,15 @@ runs:
   using: composite
   steps:
     - name: Prepare JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: temurin
-    - name: Install Clojure CLI
-      shell: bash
-      run: >-
-        curl -O https://download.clojure.org/install/linux-install-1.10.3.1075.sh &&
-        sudo bash ./linux-install-1.10.3.1075.sh
-    - name: Get M2 Cache
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@9.5
+      with:
+        cli: 1.11.1.1208
+    - name: Cache Dependencies
       uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,16 +5,6 @@ on:
   pull_request:
 
 jobs:
-  Test-Java-8:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3.2.0
-      - uses: ./.github/actions/setup
-        with:
-          java-version: 8
-          cache-key: "test"
-      - run: clojure -X:dev:test
 
   Test-Java-11:
     runs-on: ubuntu-latest

--- a/deps.edn
+++ b/deps.edn
@@ -10,11 +10,11 @@
   hiccup/hiccup                       {:mvn/version "1.0.5"}
   org.apache.santuario/xmlsec         {:mvn/version "3.0.1"} ; use latest version and override transient dep from OpenSAML
   org.cryptacular/cryptacular         {:mvn/version "1.2.5"} ; use latest version and override transient dep from OpenSAML
-  org.opensaml/opensaml-core          {:mvn/version "3.4.6"}
-  org.opensaml/opensaml-saml-api      {:mvn/version "3.4.6"}
-  org.opensaml/opensaml-saml-impl     {:mvn/version "3.4.6"}
-  org.opensaml/opensaml-xmlsec-api    {:mvn/version "3.4.6"}
-  org.opensaml/opensaml-xmlsec-impl   {:mvn/version "3.4.6"}
+  org.opensaml/opensaml-core          {:mvn/version "4.2.0"}
+  org.opensaml/opensaml-saml-api      {:mvn/version "4.2.0"}
+  org.opensaml/opensaml-saml-impl     {:mvn/version "4.2.0"}
+  org.opensaml/opensaml-xmlsec-api    {:mvn/version "4.2.0"}
+  org.opensaml/opensaml-xmlsec-impl   {:mvn/version "4.2.0"}
   potemkin/potemkin                   {:mvn/version "0.4.6"}
   pretty/pretty                       {:mvn/version "1.0.5"}
   ring/ring-codec                     {:mvn/version "1.2.0"}}


### PR DESCRIPTION
Since Java 8 is not actively supported upstream anymore, and we don't support it upstream in Metabase, we can drop support for it here. This was previously blocking the upgrade to OpenSAML 4.x. We can upgrade it now

Resolves #52