### PR TITLE
Set `disallow-doctype-decl` flag on XML parser

### DIFF
--- a/src/saml20_clj/xml.clj
+++ b/src/saml20_clj/xml.clj
@@ -1,10 +1,8 @@
 (ns saml20-clj.xml
-  (:require
-   [saml20-clj.encode-decode :as encode-decode])
-  (:import
-   (javax.xml XMLConstants)
-   (javax.xml.parsers DocumentBuilder DocumentBuilderFactory)
-   (org.w3c.dom Document)))
+  (:require [saml20-clj.encode-decode :as encode-decode])
+  (:import [javax.xml.parsers DocumentBuilder DocumentBuilderFactory]
+           javax.xml.XMLConstants
+           org.w3c.dom.Document))
 
 (defn document-builder
   ^DocumentBuilder []

--- a/src/saml20_clj/xml.clj
+++ b/src/saml20_clj/xml.clj
@@ -1,9 +1,10 @@
 (ns saml20-clj.xml
-  (:require [saml20-clj.encode-decode :as encode-decode])
+  (:require
+   [saml20-clj.encode-decode :as encode-decode])
   (:import
-   [javax.xml XMLConstants]
-   [javax.xml.parsers DocumentBuilder DocumentBuilderFactory]
-   org.w3c.dom.Document))
+   (javax.xml XMLConstants)
+   (javax.xml.parsers DocumentBuilder DocumentBuilderFactory)
+   (org.w3c.dom Document)))
 
 (defn document-builder
   ^DocumentBuilder []

--- a/src/saml20_clj/xml.clj
+++ b/src/saml20_clj/xml.clj
@@ -1,7 +1,9 @@
 (ns saml20-clj.xml
   (:require [saml20-clj.encode-decode :as encode-decode])
-  (:import [javax.xml.parsers DocumentBuilder DocumentBuilderFactory]
-           org.w3c.dom.Document))
+  (:import
+   [javax.xml XMLConstants]
+   [javax.xml.parsers DocumentBuilder DocumentBuilderFactory]
+   org.w3c.dom.Document))
 
 (defn document-builder
   ^DocumentBuilder []
@@ -10,6 +12,9 @@
      (.setNamespaceAware true)
      (.setFeature "http://xml.org/sax/features/external-parameter-entities" false)
      (.setFeature "http://apache.org/xml/features/nonvalidating/load-external-dtd" false)
+     (.setFeature "http://apache.org/xml/features/disallow-doctype-decl" true)
+     (.setFeature XMLConstants/FEATURE_SECURE_PROCESSING true)
+     (.setXIncludeAware false)
      (.setExpandEntityReferences false))))
 
 (defn clone-document [^org.w3c.dom.Document document]

--- a/test/saml20_clj/xml_test.clj
+++ b/test/saml20_clj/xml_test.clj
@@ -1,0 +1,12 @@
+(ns saml20-clj.xml-test
+  (:require [clojure.test :refer :all]
+            [saml20-clj.xml :as xml]))
+
+(deftest str->xmldoc-test
+  (testing "str->xmldoc errors if the input XML contains a DOCTYPE declaration"
+    (let [xml-str (str
+                   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                   "<!DOCTYPE root [<!ENTITY test SYSTEM 'http://example.com'>]>"
+                   "<root>&test;</root>")]
+      (is (thrown? org.xml.sax.SAXParseException
+                   (xml/str->xmldoc xml-str))))))


### PR DESCRIPTION
Sets `http://apache.org/xml/features/disallow-doctype-decl` to `true`, as well as a couple other configs, per https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j