### PR TITLE
Adds SP-initiated LogoutRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Clojars Project](https://clojars.org/metabase/saml20-clj/latest-version.svg)](http://clojars.org/metabase/saml20-clj)
 
 
-This is a SAML 2.0 Clojure library for SSO acting as a fairly thin wrapper around the Java libraries [OpenSAML
+This is a SAML 2.0 Clojure library for SSO acting as a thin wrapper around the Java libraries [OpenSAML
 v4](https://wiki.shibboleth.net/confluence/display/OS30/Home) and some utility functions from [OneLogin's SAML
 library](https://github.com/onelogin/java-saml) This library allows a Clojure application to act as a Service Provider
 (SP).

--- a/src/saml20_clj/core.clj
+++ b/src/saml20_clj/core.clj
@@ -38,7 +38,10 @@
 
  [request
   idp-redirect-response
-  request]
+  request
+  logout-redirect-location
+  idp-logout-redirect-response
+  make-logout-request-xml]
 
  [response
   decrypt-response

--- a/src/saml20_clj/sp/metadata.clj
+++ b/src/saml20_clj/sp/metadata.clj
@@ -30,9 +30,7 @@
            [:ds:X509Data
             [:ds:X509Certificate encoded-cert]]]])
        (when slo-url
-         (list
-           [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" :Location slo-url}]
-           [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" :Location slo-url}]))
+         [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" :Location slo-url}])
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]

--- a/src/saml20_clj/sp/metadata.clj
+++ b/src/saml20_clj/sp/metadata.clj
@@ -30,8 +30,9 @@
            [:ds:X509Data
             [:ds:X509Certificate encoded-cert]]]])
        (when slo-url
-         [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                                   :Location slo-url}])
+         (list
+           [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" :Location slo-url}]
+           [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" :Location slo-url}]))
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"]
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"]
        [:md:NameIDFormat "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"]

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -130,12 +130,15 @@
 
 (defn idp-logout-redirect-response
   "Return Ring response for HTTP 302 redirect."
-  [idp-url saml-request relay-state issuer]
-  (let [url (logout-redirect-location
-              :issuer issuer
-              :idp-url idp-url
-              :saml-request saml-request
-              :relay-state relay-state)]
-    {:status  302 ; found
-     :headers {"Location" url}
-     :body    ""}))
+  ([issuer user-email idp-url relay-state]
+   (idp-logout-redirect-response issuer user-email idp-url relay-state (random-request-id)))
+  ([issuer user-email idp-url relay-state request-id]
+   (let [url (logout-redirect-location
+               :idp-url idp-url
+               :user-email user-email
+               :issuer issuer
+               :relay-state relay-state
+               :request-id request-id)]
+     {:status  302 ; found
+      :headers {"Location" url}
+      :body    ""})))

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -93,11 +93,12 @@
      :headers {"Location" url}
      :body    ""}))
 
-;; Wanted to call this make-request-xml, but it gets exported in core.clj, which
+;; I wanted to call this make-request-xml, but it gets exported in core.clj, which
 ;; warrants the request prefix
-(defn make-logout-request-xml [& {:keys [request-id instant idp-url issuer user-email]
-                                  :or {
-                                       instant (format-instant (t/instant))}}]
+(defn make-logout-request-xml
+  "Generates a SAML 2.0 logout request, as a hiccupey datastructure."
+  [& {:keys [request-id instant idp-url issuer user-email]
+      :or {instant (format-instant (t/instant))}}]
   (assert (non-blank-string? idp-url) "idp-url is required")
   (assert (non-blank-string? issuer) "issuer is required")
   (assert (non-blank-string? user-email) "user-email is required")

--- a/src/saml20_clj/sp/response.clj
+++ b/src/saml20_clj/sp/response.clj
@@ -1,7 +1,7 @@
 (ns saml20-clj.sp.response
   "Code for parsing the XML response (as a String)from the IdP to an OpenSAML `Response`, and for basic operations like
   validating the signature and reading assertions."
-  (:require [java-time :as t]
+  (:require [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.crypto :as crypto]
             [saml20-clj.state :as state]
@@ -313,7 +313,7 @@
 
   Check the javadoc of OpenSAML at:
 
-  https://build.shibboleth.net/nexus/service/local/repositories/releases/archive/org/opensaml/opensaml/2.5.3/opensaml-2.5.3-javadoc.jar/!/index.html"
+  https://web.archive.org/web/20150421234900/https://build.shibboleth.net/nexus/service/local/repositories/releases/archive/org/opensaml/opensaml/2.5.3/opensaml-2.5.3-javadoc.jar/!/index.html"
   [response]
   (when-let [response (coerce/->Response response)]
     (let [status (.. response getStatus getStatusCode getValue)]

--- a/src/saml20_clj/state.clj
+++ b/src/saml20_clj/state.clj
@@ -1,5 +1,5 @@
 (ns saml20-clj.state
-  (:require [java-time :as t]
+  (:require [java-time.api :as t]
             [pretty.core :as pretty]))
 
 (defprotocol StateManager

--- a/test/saml20_clj/coerce_test.clj
+++ b/test/saml20_clj/coerce_test.clj
@@ -139,10 +139,10 @@ c7tL1QjbfAUHAQYwmHkWgPP+T2wAv0pOt36GgMCM
       (testing "public only"
         (is (= idp-fingerprints
                (x509-credential-fingerprints (coerce/->Credential {:filename test/keystore-filename
-                                                                       :password test/keystore-password
-                                                                       :alias    "idp"})))))
+                                                                   :password test/keystore-password
+                                                                   :alias    "idp"})))))
       (testing "public + private"
         (is (= sp-fingerprints
                (x509-credential-fingerprints (coerce/->Credential {:filename test/keystore-filename
-                                                                       :password test/keystore-password
-                                                                       :alias    "sp"}))))))))
+                                                                   :password test/keystore-password
+                                                                   :alias    "sp"}))))))))

--- a/test/saml20_clj/crypto_test.clj
+++ b/test/saml20_clj/crypto_test.clj
@@ -59,28 +59,28 @@
 (deftest sign-request-test-bad-params
   (testing "Signature should throw errors with bad params"
     (let [signed (coerce/->Element (coerce/->xml-string
-                                   [:samlp:AuthnRequest
-                                    {:xmlns:samlp                 "urn:oasis:names:tc:SAML:2.0:protocol"
-                                     :ID                          1234
-                                     :Version                     "2.0"
-                                     :IssueInstant                1234
-                                     :ProtocolBinding             "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                                     :ProviderName                "name"
-                                     :IsPassive                   false
-                                     :Destination                 "url"
-                                     :AssertionConsumerServiceURL "url"}
-                                    [:saml:Issuer
-                                     {:xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"}
-                                     "issuer"]]))]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"No matching signature algorithm"
-             (crypto/sign signed test/sp-private-key :signature-algorithm [:rsa :crazy])))
+                                    [:samlp:AuthnRequest
+                                     {:xmlns:samlp                 "urn:oasis:names:tc:SAML:2.0:protocol"
+                                      :ID                          1234
+                                      :Version                     "2.0"
+                                      :IssueInstant                1234
+                                      :ProtocolBinding             "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                      :ProviderName                "name"
+                                      :IsPassive                   false
+                                      :Destination                 "url"
+                                      :AssertionConsumerServiceURL "url"}
+                                     [:saml:Issuer
+                                      {:xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"}
+                                      "issuer"]]))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"No matching signature algorithm"
+           (crypto/sign signed test/sp-private-key :signature-algorithm [:rsa :crazy])))
 
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #"matching canonicalization algorithm"
-             (crypto/sign signed test/sp-private-key :canonicalization-algorithm [:bad]))))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"matching canonicalization algorithm"
+           (crypto/sign signed test/sp-private-key :canonicalization-algorithm [:bad]))))))
 
 (deftest has-private-key-test
   (testing "has private key"

--- a/test/saml20_clj/crypto_test.clj
+++ b/test/saml20_clj/crypto_test.clj
@@ -1,6 +1,6 @@
 (ns saml20-clj.crypto-test
   (:require [clojure.test :refer :all]
-            [java-time :as t]
+            [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.crypto :as crypto]
             [saml20-clj.sp.request :as request]

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -191,3 +191,34 @@
                    java.lang.AssertionError
                    (re-pattern (format "%s is required" (name k)))
                    (request/request request))))))))))
+
+(deftest logout-request-test
+  (let [logout-xml (t/with-clock (t/mock-clock (t/instant "2020-09-24T22:51:00.000Z"))
+                     (request/make-logout-request-xml
+                       {:request-id "ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24"
+                        :user-email "user@example.com"
+                        :idp-url    "http://idp.example.com/SSOService.php"
+                        :issuer     "http://sp.example.com/demo1/metadata.php"}))]
+    (is (= [:samlp:LogoutRequest
+            {:xmlns:samlp "urn:oasis:names:tc:SAML:2.0:protocol"
+             :xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"
+             :Version "2.0"
+             :ID "ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24"
+             :IssueInstant "2020-09-24T22:51:00Z"
+             :Destination "http://idp.example.com/SSOService.php"}
+            [:saml:Issuer "http://sp.example.com/demo1/metadata.php"]
+            [:saml:NameID {:Format "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"} "user@example.com"]
+            [:samlp:SessionIndex "SessionIndex_From_Authentication_Assertion"]]
+          logout-xml))
+    (is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" "\n"
+                "<samlp:LogoutRequest Destination=\"http://idp.example.com/SSOService.php\" "
+                "ID=\"ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24\" "
+                "IssueInstant=\"2020-09-24T22:51:00Z\" "
+                "Version=\"2.0\" "
+                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
+                "xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\">"
+                "<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>"
+                "<saml:NameID Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress\">user@example.com</saml:NameID>"
+                "<samlp:SessionIndex>SessionIndex_From_Authentication_Assertion</samlp:SessionIndex>"
+                "</samlp:LogoutRequest>")
+           (coerce/->xml-string logout-xml)))))

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -1,7 +1,7 @@
 (ns saml20-clj.sp.request-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
-            [java-time :as t]
+            [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.sp.request :as request]
             [saml20-clj.test :as test]))

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -260,3 +260,18 @@
              (encode-decode/base64->inflate->str SAMLRequest))
           "SAMLRequest is generated correctly")
       (is (= issuer (encode-decode/base64->str RelayState))))))
+
+(deftest idp-logout-redirect-response-test
+  (t/with-clock (t/mock-clock (t/instant "2020-09-24T22:51:00.000Z"))
+    (let [req-id "ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24"
+          idp-url "http://idp.example.com/SSOService.php"
+          user-email "user@example.com"
+          issuer "http://sp.example.com/demo1/metadata.php"
+          logout-url (request/logout-redirect-location
+                       {:issuer     issuer
+                        :user-email user-email
+                        :idp-url    idp-url
+                        :request-id req-id
+                        :relay-state (encode-decode/str->base64 issuer)})
+          redirect (request/idp-logout-redirect-response issuer user-email idp-url (encode-decode/str->base64 issuer) req-id)]
+      (is (= logout-url (get-in redirect [:headers "Location"]))))))

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -1,13 +1,12 @@
 (ns saml20-clj.sp.request-test
   (:require [clojure.string :as str]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is testing]]
             [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.encode-decode :as encode-decode]
             [saml20-clj.sp.request :as request]
-            [saml20-clj.test :as test]
-            [saml20-clj.encode-decode :as encode])
-  (:import [java.net URI URLDecoder]))
+            [saml20-clj.test :as test])
+  (:import [java.net URI]))
 
 (def target-uri "http://sp.example.com/demo1/index.php?acs")
 
@@ -255,9 +254,9 @@
              :user-email user-email
              :idp-url    idp-url
              :request-id req-id
-             :relay-state (encode-decode/str->base64 issuer)})]
-      (let [{:strs [SAMLRequest RelayState]} (parse-query-params location)]
-        (is (= (coerce/->xml-string (request/make-logout-request-xml :request-id req-id :idp-url idp-url :issuer issuer :user-email user-email))
-               (encode-decode/base64->inflate->str SAMLRequest))
-            "SAMLRequest is generated correctly")
-        (is (= issuer (encode-decode/base64->str RelayState)))))))
+             :relay-state (encode-decode/str->base64 issuer)})
+          {:strs [SAMLRequest RelayState]} (parse-query-params location)]
+      (is (= (coerce/->xml-string (request/make-logout-request-xml :request-id req-id :idp-url idp-url :issuer issuer :user-email user-email))
+             (encode-decode/base64->inflate->str SAMLRequest))
+          "SAMLRequest is generated correctly")
+      (is (= issuer (encode-decode/base64->str RelayState))))))

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -6,7 +6,7 @@
             [saml20-clj.encode-decode :as encode-decode]
             [saml20-clj.sp.request :as request]
             [saml20-clj.test :as test])
-  (:import [java.net URI]))
+  (:import java.net.URI))
 
 (def target-uri "http://sp.example.com/demo1/index.php?acs")
 

--- a/test/saml20_clj/sp/response_test.clj
+++ b/test/saml20_clj/sp/response_test.clj
@@ -167,9 +167,9 @@
   (t/with-clock (t/mock-clock (t/instant "2020-09-24T00:00:00.000Z"))
     (is (= :valid
            (validate-assertions :not-before nil))))
-    (testing "should respect clock skew"
-      (is (= :valid
-             (validate-assertions :not-before {:allowable-clock-skew-seconds (* 60 60 24 365)}))))
+  (testing "should respect clock skew"
+    (is (= :valid
+           (validate-assertions :not-before {:allowable-clock-skew-seconds (* 60 60 24 365)}))))
   (t/with-clock (t/mock-clock (t/instant "2010-09-24T00:00:00.000Z"))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
@@ -295,7 +295,7 @@
                              :address         "192.168.1.1",
                              :recipient       "http://sp.example.com/demo1/index.php?acs"}}
              (response/Assertion->map
-               (first (response/opensaml-assertions (coerce/->Response response))))))))
+              (first (response/opensaml-assertions (coerce/->Response response))))))))
   (testing "Attribute Nodes sharing a Name will collect all of their contained Attribute Value Nodes."
     (let [response (test/response {})]
       (is (= {"uid"                  '("test")
@@ -305,4 +305,4 @@
               ;; this key is from two Attribute nodes with the same Name
               "member_of"            '("test-group1" "test-group2" "test-group3")}
              (:attrs (response/Assertion->map
-                       (first (response/opensaml-assertions (coerce/->Response response))))))))))
+                      (first (response/opensaml-assertions (coerce/->Response response))))))))))

--- a/test/saml20_clj/sp/response_test.clj
+++ b/test/saml20_clj/sp/response_test.clj
@@ -1,6 +1,6 @@
 (ns saml20-clj.sp.response-test
   (:require [clojure.test :refer :all]
-            [java-time :as t]
+            [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.sp.response :as response]
             [saml20-clj.test :as test])

--- a/test/saml20_clj/state_test.clj
+++ b/test/saml20_clj/state_test.clj
@@ -1,6 +1,6 @@
 (ns saml20-clj.state-test
   (:require [clojure.test :refer :all]
-            [java-time :as t]
+            [java-time.api :as t]
             [saml20-clj.coerce :as coerce]
             [saml20-clj.sp.request :as request]
             [saml20-clj.sp.response :as response]


### PR DESCRIPTION
# The basic flow of a SAML logout is:

  1. A SSO SAML User clicks Sign Out.
  2. Service Provider issues a redirect to the client with a LogoutRequest to the Identity Provider.
  3. Client forwards the request to the Identity Provider.
  4. Identity Provider logs the user out + redirects client back to Service Provider with a LogoutResponse.
  5. Service Provider clears the user's session, responds to the client with a redirect to the home page.

This adds `logout-redirect-location` and `idp-logout-redirect-response`, which are used to send a LogoutRequest to an Identity Provider. Some users of this library (like Metabase) prefer to send the redirect url in a POST body, and let the client initiate the redirect, and that's what `logout-redirect-location` is for.