### PR TITLE
Add license info for clojars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 /classes
 /config.edn
 /lib
-/pom.xml
 /pom.xml.asc
 /profiles.clj
 /resources/public/js/main.js

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <licenses>
+    <license>
+      <name>Eclipse Public License 2.0</name>
+      <url>https://www.eclipse.org/legal/epl-2.0/</url>
+      <distribution>repo</distribution>
+      <comments>An open source, community-driven license</comments>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
We need license info the pom.xml that we use to deploy to clojars with.

This repo uses `depstar`, and it will "sync" the pom.xml file, meaning it won't overwrite things in it, like the newly added license section.