### PR TITLE
New SLO shape improves compatibility + fix codecov uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,5 +39,9 @@ jobs:
           cache-key: "cloverage"
       - run: clojure -X:dev:cloverage
       - name: Upload code coverage to codecov.io
-        run: >-
-          bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: target/coverage/codecov.json
+          flags: cloverage
+          name: codecov-umbrella

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -102,15 +102,15 @@
   (assert (non-blank-string? idp-url) "idp-url is required")
   (assert (non-blank-string? issuer) "issuer is required")
   (assert (non-blank-string? user-email) "user-email is required")
-  [:samlp:LogoutRequest {:xmlns:samlp "urn:oasis:names:tc:SAML:2.0:protocol"
+  [:samlp:LogoutRequest {:xmlns "urn:oasis:names:tc:SAML:2.0:protocol"
+                         :xmlns:samlp "urn:oasis:names:tc:SAML:2.0:protocol"
                          :xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"
                          :Version "2.0"
                          :ID (or request-id (str "id" (random-uuid)))
                          :IssueInstant instant
                          :Destination idp-url}
-   [:saml:Issuer issuer]
-   [:saml:NameID {:Format "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"} user-email]
-   [:samlp:SessionIndex "SessionIndex_From_Authentication_Assertion"]])
+   [:Issuer issuer]
+   [:NameID {:Format "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"} user-email]])
 
 (defn logout-redirect-location
   "This returns a url that you'd want to redirect a client to. Either using

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -202,28 +202,16 @@
                        :idp-url    "http://idp.example.com/SSOService.php"
                        :issuer     "http://sp.example.com/demo1/metadata.php"}))]
     (is (= [:samlp:LogoutRequest
-            {:xmlns:samlp "urn:oasis:names:tc:SAML:2.0:protocol"
+            {:xmlns "urn:oasis:names:tc:SAML:2.0:protocol"
+             :xmlns:samlp "urn:oasis:names:tc:SAML:2.0:protocol"
              :xmlns:saml "urn:oasis:names:tc:SAML:2.0:assertion"
              :Version "2.0"
              :ID "ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24"
              :IssueInstant "2020-09-24T22:51:00Z"
              :Destination "http://idp.example.com/SSOService.php"}
-            [:saml:Issuer "http://sp.example.com/demo1/metadata.php"]
-            [:saml:NameID {:Format "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"} "user@example.com"]
-            [:samlp:SessionIndex "SessionIndex_From_Authentication_Assertion"]]
-           logout-xml))
-    (is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" "\n"
-                "<samlp:LogoutRequest Destination=\"http://idp.example.com/SSOService.php\" "
-                "ID=\"ONELOGIN_109707f0030a5d00620c9d9df97f627afe9dcc24\" "
-                "IssueInstant=\"2020-09-24T22:51:00Z\" "
-                "Version=\"2.0\" "
-                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
-                "xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\">"
-                "<saml:Issuer>http://sp.example.com/demo1/metadata.php</saml:Issuer>"
-                "<saml:NameID Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress\">user@example.com</saml:NameID>"
-                "<samlp:SessionIndex>SessionIndex_From_Authentication_Assertion</samlp:SessionIndex>"
-                "</samlp:LogoutRequest>")
-           (coerce/->xml-string logout-xml)))))
+            [:Issuer "http://sp.example.com/demo1/metadata.php"]
+            [:NameID {:Format "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"} "user@example.com"]]
+           logout-xml))))
 
 (t/with-clock (t/mock-clock (t/instant "2020-09-24T22:51:00.000Z"))
   (request/logout-redirect-location

--- a/test/saml20_clj/sp/request_test.clj
+++ b/test/saml20_clj/sp/request_test.clj
@@ -189,8 +189,7 @@
         (doseq [v [nil "" "    " false true 100]]
           (testing (format "\n%s = %s" k (pr-str v))
             (let [request (assoc request k v)]
-              (is (thrown-with-msg?
-                   java.lang.AssertionError
+              (is (thrown-with-msg? java.lang.AssertionError
                    (re-pattern (format "%s is required" (name k)))
                    (request/request request))))))))))
 

--- a/test/saml20_clj/sp/response_test.clj
+++ b/test/saml20_clj/sp/response_test.clj
@@ -47,7 +47,7 @@
           (testing (str "\noriginal =\n" (coerce/->xml-string original))
             (testing (str "decrypted =\n" (coerce/->xml-string decrypted))
               (prn :original (coerce/->xml-string original))
-              (prn :descrypted (coerce/->xml-string decrypted))
+              (prn :decrypted (coerce/->xml-string decrypted))
               (is (= 0
                      (count (.getEncryptedAssertions decrypted))))
               (is (= 1


### PR DESCRIPTION
Keycloak is a little more lenient than Microsoft Azure Active Directory ([aka Microsoft Entra ID](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id)). So I've updated the shape to match the [Entra ID docs](https://learn.microsoft.com/en-us/entra/identity-platform/single-sign-out-saml-protocol#logoutrequest). This shape of a SLO logout request works on both.

Tested with:
- [x] Azure AD
- [x] keycloak