### PR TITLE
Bump dependencies August 2024

### DIFF
--- a/.clj-kondo/potemkin/potemkin/config.edn
+++ b/.clj-kondo/potemkin/potemkin/config.edn
@@ -1,0 +1,62 @@
+{:lint-as {potemkin.collections/compile-if      clojure.core/if
+           potemkin.collections/reify-map-type  clojure.core/reify
+           potemkin.collections/def-map-type    clj-kondo.lint-as/def-catch-all
+           potemkin.collections/def-derived-map clj-kondo.lint-as/def-catch-all
+
+           potemkin.types/reify+                clojure.core/reify
+           potemkin.types/defprotocol+          clojure.core/defprotocol
+           potemkin.types/deftype+              clojure.core/deftype
+           potemkin.types/defrecord+            clojure.core/defrecord
+           potemkin.types/definterface+         clojure.core/defprotocol
+           potemkin.types/extend-protocol+      clojure.core/extend-protocol
+           potemkin.types/def-abstract-type     clj-kondo.lint-as/def-catch-all
+
+           potemkin.utils/doit                  clojure.core/doseq
+           potemkin.utils/doary                 clojure.core/doseq
+           potemkin.utils/condp-case            clojure.core/condp
+           potemkin.utils/fast-bound-fn         clojure.core/bound-fn
+
+           potemkin.walk/prewalk                clojure.walk/prewalk
+           potemkin.walk/postwalk               clojure.walk/postwalk
+           potemkin.walk/walk                   clojure.walk/walk
+
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           ;;;; top-level from import-vars
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+           ;; Have hooks
+           ;;potemkin/import-fn potemkin.namespaces/import-fn
+           ;;potemkin/import-macro potemkin.namespaces/import-macro
+           ;;potemkin/import-def potemkin.namespaces/import-def
+
+           ;; Internal, not transitive
+           ;;potemkin/unify-gensyms               potemkin.macros/unify-gensyms
+           ;;potemkin/normalize-gensyms           potemkin.macros/normalize-gensyms
+           ;;potemkin/equivalent?                 potemkin.macros/equivalent?
+
+           potemkin/condp-case                  clojure.core/condp
+           potemkin/doit                        potemkin.utils/doit
+           potemkin/doary                       potemkin.utils/doary
+
+           potemkin/def-abstract-type           clj-kondo.lint-as/def-catch-all
+           potemkin/reify+                      clojure.core/reify
+           potemkin/defprotocol+                clojure.core/defprotocol
+           potemkin/deftype+                    clojure.core/deftype
+           potemkin/defrecord+                  clojure.core/defrecord
+           potemkin/definterface+               clojure.core/defprotocol
+           potemkin/extend-protocol+            clojure.core/extend-protocol
+
+           potemkin/reify-map-type              clojure.core/reify
+           potemkin/def-derived-map             clj-kondo.lint-as/def-catch-all
+           potemkin/def-map-type                clj-kondo.lint-as/def-catch-all}
+
+ ;; leave import-vars alone, kondo special-cases it
+ :hooks   {:macroexpand {#_#_potemkin.namespaces/import-vars potemkin.namespaces/import-vars
+                         potemkin.namespaces/import-fn    potemkin.namespaces/import-fn
+                         potemkin.namespaces/import-macro potemkin.namespaces/import-macro
+                         potemkin.namespaces/import-def   potemkin.namespaces/import-def
+
+                         #_#_potemkin/import-vars potemkin.namespaces/import-vars
+                         potemkin/import-fn               potemkin.namespaces/import-fn
+                         potemkin/import-macro            potemkin.namespaces/import-macro
+                         potemkin/import-def              potemkin.namespaces/import-def}}}

--- a/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
+++ b/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
@@ -1,0 +1,56 @@
+(ns potemkin.namespaces
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn import-macro*
+  ([sym]
+   `(def ~(-> sym name symbol) ~sym))
+  ([sym name]
+   `(def ~name ~sym)))
+
+(defmacro import-fn
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-macro
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-def
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+#_
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                           #(symbol
+                              (str (first x)
+                                   (when-let [n (namespace %)]
+                                     (str "." n)))
+                              (name %))))
+                    [x]))
+        syms (mapcat unravel syms)
+        result `(do
+                  ~@(map
+                      (fn [sym]
+                        (let [vr (resolve sym)
+                              m (meta vr)]
+                          (cond
+                            (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                            (:macro m) `(def ~(-> sym name symbol) ~sym)
+                            (:arglists m) `(def ~(-> sym name symbol) ~sym)
+                            :else `(def ~(-> sym name symbol) ~sym))))
+                      syms))]
+    result))

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "check"
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "eastwood"
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "namespace-declarations"
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "reflection-warnings"
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "whitespace"
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           cache-key: "kondo"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           java-version: 11
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           java-version: 17
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4.1.7
       - uses: ./.github/actions/setup
         with:
           java-version: 11

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.lein-failures
 /.lein-plugins
 /.lein-repl-history
+/.lsp
 /.nrepl-port
 /build.xml
 /checkouts

--- a/deps.edn
+++ b/deps.edn
@@ -2,20 +2,20 @@
  {"opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :deps
- {org.clojure/spec.alpha              {:mvn/version "0.3.218"}
-  org.clojure/tools.logging           {:mvn/version "1.2.4"}
+ {org.clojure/spec.alpha              {:mvn/version "0.5.238"}
+  org.clojure/tools.logging           {:mvn/version "1.3.0"}
   com.onelogin/java-saml              {:mvn/version "2.9.0"}
-  clojure.java-time/clojure.java-time {:mvn/version "1.1.0"}
-  commons-io/commons-io               {:mvn/version "2.11.0"}
+  clojure.java-time/clojure.java-time {:mvn/version "1.4.2"}
+  commons-io/commons-io               {:mvn/version "2.16.1"}
   hiccup/hiccup                       {:mvn/version "1.0.5"}
-  org.apache.santuario/xmlsec         {:mvn/version "3.0.3"} ; use latest version and override transient dep from OpenSAML
-  org.cryptacular/cryptacular         {:mvn/version "1.2.5"} ; use latest version and override transient dep from OpenSAML
-  org.opensaml/opensaml-core          {:mvn/version "4.2.0"}
-  org.opensaml/opensaml-saml-api      {:mvn/version "4.2.0"}
-  org.opensaml/opensaml-saml-impl     {:mvn/version "4.2.0"}
-  org.opensaml/opensaml-xmlsec-api    {:mvn/version "4.2.0"}
-  org.opensaml/opensaml-xmlsec-impl   {:mvn/version "4.2.0"}
-  potemkin/potemkin                   {:mvn/version "0.4.6"}
+  org.apache.santuario/xmlsec         {:mvn/version "4.0.2"} ; use latest version and override transient dep from OpenSAML
+  org.cryptacular/cryptacular         {:mvn/version "1.2.7"} ; use latest version and override transient dep from OpenSAML
+  org.opensaml/opensaml-core          {:mvn/version "4.3.2"}
+  org.opensaml/opensaml-saml-api      {:mvn/version "4.3.2"}
+  org.opensaml/opensaml-saml-impl     {:mvn/version "4.3.2"}
+  org.opensaml/opensaml-xmlsec-api    {:mvn/version "4.3.2"}
+  org.opensaml/opensaml-xmlsec-impl   {:mvn/version "4.3.2"}
+  potemkin/potemkin                   {:mvn/version "0.4.7"}
   pretty/pretty                       {:mvn/version "1.0.5"}
   ring/ring-codec                     {:mvn/version "1.2.0"}}
 
@@ -33,12 +33,12 @@
   ;; clojure -M:check
   :check
   {:extra-deps {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"
-                                 :sha     "518d5a1cbfcd7c952f548e6dbfcb9a4a5faf9062"}}
+                                 :sha     "d997df866b2a04b7ce7b17533093ee0a2e2cb729"}}
    :main-opts  ["-m" "clj-check.check"]}
 
   ;; clojure -X:dev:eastwood
   :eastwood
-  {:extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}
+  {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
    :exec-fn    eastwood.lint/eastwood-from-cmdline
    :exec-args  {:source-paths    ["src"]
                 :add-linters     [:unused-fn-args
@@ -68,7 +68,7 @@
 
   ;; clojure -M:kondo
   :kondo
-  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2022.12.10"}}
+  {:replace-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.01"}}
    :main-opts    ["-m" "clj-kondo.main"
                   "--lint" "src"]}
 
@@ -91,6 +91,6 @@
   ;; clojure -T:build build
   ;; clojure -T:build deploy
   :build
-  {:deps       {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+  {:deps       {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                 slipset/deps-deploy           {:mvn/version "0.2.2"}}
    :ns-default build}}}


### PR DESCRIPTION
Bump dependencies for everything. I didn't upgrade OpenSAML to the 4.x libraries yet, just the latest 3.x release. Not sure if there are breaking changes or not there -- I'll investigate this separately after this lands.