### PR TITLE
fix: make sure tests/lints run once on PRs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,8 @@ name: Linters
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
PRs cause all workflow tasks to run twice (since it's running on the push and the pr trigger). This makes the workflow only run on push to master and on the pr trigger so they will only run once on PRs.