### PR TITLE
fix: generate signed SLO requests

### DIFF
--- a/src/saml20_clj/core.clj
+++ b/src/saml20_clj/core.clj
@@ -40,8 +40,7 @@
   idp-redirect-response
   request
   logout-redirect-location
-  idp-logout-redirect-response
-  make-logout-request-xml]
+  idp-logout-redirect-response]
 
  [response
   decrypt-response

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -1,4 +1,4 @@
- (ns saml20-clj.sp.request
+(ns saml20-clj.sp.request
   (:require [clojure.string :as str]
             [java-time.api :as t]
             [saml20-clj.coerce :as coerce]

--- a/src/saml20_clj/sp/request.clj
+++ b/src/saml20_clj/sp/request.clj
@@ -165,8 +165,7 @@
                                     SAMLConstants/SAML20_NS
                                     "NameID"
                                     "saml")
-                  (.setValue user-email))))
-  )
+                  (.setValue user-email)))))
 
 (defn idp-logout-redirect-response
   "Return Ring response for HTTP 302 redirect."


### PR DESCRIPTION
Updates our SLO request generation system using the same principles as the previous changes to the AuthnRequest generation.

This does drop the make-logout-request-xml function from the public API.