### PR TITLE
fix: update actions/cache version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,7 @@ runs:
       with:
         cli: 1.11.1.1208
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2


### PR DESCRIPTION
v2 seems to be permanently gone now