### PR TITLE
[No Jira Issue] Add support for distinct signing and encryption certificates in SAML metadata

### DIFF
--- a/src/saml20_clj/sp/metadata.clj
+++ b/src/saml20_clj/sp/metadata.clj
@@ -4,15 +4,23 @@
              [coerce :as coerce]
              [encode-decode :as encode]]))
 
-(defn metadata [{:keys [app-name acs-url slo-url sp-cert
+(defn metadata [{:keys [app-name acs-url slo-url
+                        sp-cert                            ; legacy - for backward compatibility
+                        sp-encryption-cert sp-signing-cert
                         requests-signed
                         want-assertions-signed]
                  :or {want-assertions-signed true
                       requests-signed true}}]
-  (let [encoded-cert (some-> ^java.security.cert.X509Certificate sp-cert
-                             .getEncoded
-                             encode/encode-base64
-                             encode/bytes->str)]
+  (let [signing-cert (or sp-signing-cert sp-cert)
+        encryption-cert (or sp-encryption-cert sp-cert)
+        encoded-signing-cert (some-> ^java.security.cert.X509Certificate signing-cert
+                                     .getEncoded
+                                     encode/encode-base64
+                                     encode/bytes->str)
+        encoded-encryption-cert (some-> ^java.security.cert.X509Certificate encryption-cert
+                                        .getEncoded
+                                        encode/encode-base64
+                                        encode/bytes->str)]
     (coerce/->xml-string
      [:md:EntityDescriptor {:xmlns:md "urn:oasis:names:tc:SAML:2.0:metadata"
                             :ID       (str/replace acs-url #"[:/]" "_")
@@ -20,16 +28,16 @@
       [:md:SPSSODescriptor {:AuthnRequestsSigned        (str requests-signed)
                             :WantAssertionsSigned       (str want-assertions-signed)
                             :protocolSupportEnumeration "urn:oasis:names:tc:SAML:2.0:protocol"}
-       (when encoded-cert
+       (when encoded-signing-cert
          [:md:KeyDescriptor  {:use "signing"}
           [:ds:KeyInfo  {:xmlns:ds "http://www.w3.org/2000/09/xmldsig#"}
            [:ds:X509Data
-            [:ds:X509Certificate encoded-cert]]]])
-       (when encoded-cert
+            [:ds:X509Certificate encoded-signing-cert]]]])
+       (when encoded-encryption-cert
          [:md:KeyDescriptor  {:use "encryption"}
           [:ds:KeyInfo  {:xmlns:ds "http://www.w3.org/2000/09/xmldsig#"}
            [:ds:X509Data
-            [:ds:X509Certificate encoded-cert]]]])
+            [:ds:X509Certificate encoded-encryption-cert]]]])
        (when slo-url
          [:md:SingleLogoutService {:Binding "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                                    :Location slo-url}])


### PR DESCRIPTION
Best practices in crypto is using separate key pairs for signing and encryption operations. This change adds optional sp-signing-cert and sp-encryption-cert parameters to the metadata function while maintaining full backward compatibility with the existing sp-cert parameter.

When sp-signing-cert and sp-encryption-cert are not provided, the function falls back to sp-cert for both KeyDescriptor elements, preserving existing behavior.